### PR TITLE
gx publish 1.0.7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 iptb/iptb
+.idea/

--- a/.gx/lastpubver
+++ b/.gx/lastpubver
@@ -1,1 +1,1 @@
-1.0.6: QmQwfyu1QgiKduoRqrztTA4yPWWx2dkntkuD5KzbXy77mc
+1.0.7: Qme2p7yKLjaYMQ89HYt5P4N7AkNHhdBydjAiWogeYqEK4a

--- a/package.json
+++ b/package.json
@@ -39,9 +39,9 @@
     },
     {
       "author": "magik6k",
-      "hash": "QmYyzmMnhNTtoXx5ttgUaRdHHckYnQWjPL98hgLAR2QLDD",
+      "hash": "QmbZ4DPNi99YQwzFSKsdU7pLmieiWs7ajGkPrfvpGjfAFN",
       "name": "go-ipfs-config",
-      "version": "0.2.21"
+      "version": "0.2.22"
     },
     {
       "author": "whyrusleeping",
@@ -62,6 +62,6 @@
   "license": "",
   "name": "iptb-plugins",
   "releaseCmd": "git commit -a -m \"gx publish $VERSION\"",
-  "version": "1.0.6"
+  "version": "1.0.7"
 }
 


### PR DESCRIPTION
Update go-ipfs-config dependency to [this version](https://github.com/ipfs/go-ipfs-config/pull/5) to satisfy dependencies in this [go-ipfs PR](https://github.com/ipfs/go-ipfs/pull/5403)