### PR TITLE
[WIP] Add `IsAlive` implementations to plugins

### DIFF
--- a/browser/browseripfs.go
+++ b/browser/browseripfs.go
@@ -357,6 +357,10 @@ func (l *BrowserIpfs) Type() string {
 	return PluginName
 }
 
+func (l *BrowserIpfs) IsAlive() bool {
+	return ipfs.APIReachable(l)
+}
+
 func (l *BrowserIpfs) signalAndWait(p *os.Process, waitch <-chan struct{}, signal os.Signal, t time.Duration) error {
 	if err := p.Signal(signal); err != nil {
 		return errors.Wrapf(err, "error killing daemon %s", l.dir)

--- a/docker/dockeripfs.go
+++ b/docker/dockeripfs.go
@@ -171,12 +171,7 @@ func (l *DockerIpfs) Init(ctx context.Context, args ...string) (testbedi.Output,
 }
 
 func (l *DockerIpfs) Start(ctx context.Context, wait bool, args ...string) (testbedi.Output, error) {
-	alive, err := l.isAlive()
-	if err != nil {
-		return nil, err
-	}
-
-	if alive {
+	if l.IsAlive() {
 		return nil, fmt.Errorf("node is already running")
 	}
 
@@ -464,6 +459,10 @@ func (l *DockerIpfs) Type() string {
 	return "ipfs"
 }
 
+func (l *DockerIpfs) IsAlive() bool {
+	return ipfs.APIReachable(l)
+}
+
 func (l *DockerIpfs) Deployment() string {
 	return "docker"
 }
@@ -479,10 +478,6 @@ func (l *DockerIpfs) getID() (string, error) {
 	}
 
 	return string(b), nil
-}
-
-func (l *DockerIpfs) isAlive() (bool, error) {
-	return false, nil
 }
 
 func (l *DockerIpfs) env() ([]string, error) {

--- a/local/localipfs.go
+++ b/local/localipfs.go
@@ -456,6 +456,11 @@ func (l *LocalIpfs) Type() string {
 	return "ipfs"
 }
 
+func (l *LocalIpfs) IsAlive() bool {
+	alive, _ := l.isAlive()
+	return alive
+}
+
 func (l *LocalIpfs) Deployment() string {
 	return "local"
 }

--- a/localp2pd/localp2pd.go
+++ b/localp2pd/localp2pd.go
@@ -50,7 +50,6 @@ type LocalP2pd struct {
 
 	// process
 	process *os.Process
-	alive   bool
 }
 
 // NewNode creates a localp2pd iptb core node that runs the libp2p daemon on the
@@ -237,7 +236,7 @@ func (l *LocalP2pd) Init(ctx context.Context, args ...string) (testbedi.Output, 
 
 // Start launches a libp2p daemon
 func (l *LocalP2pd) Start(ctx context.Context, wait bool, args ...string) (testbedi.Output, error) {
-	if l.alive {
+	if l.IsAlive() {
 		return nil, fmt.Errorf("libp2p daemon is already running")
 	}
 
@@ -407,6 +406,11 @@ func (l *LocalP2pd) Dir() string {
 // Examples localipfs, dockeripfs, etc.
 func (l *LocalP2pd) Type() string {
 	return PluginName
+}
+
+// IsAlive returns true if the node is running and false otherwise
+func (l *LocalP2pd) IsAlive() bool {
+	return ipfs.APIReachable(l)
 }
 
 func (l *LocalP2pd) String() string {

--- a/util.go
+++ b/util.go
@@ -221,6 +221,10 @@ func SwarmAddrs(l testbedi.Core) ([]string, error) {
 	return maddrs, nil
 }
 
+func APIReachable(l testbedi.Libp2p) bool {
+	return tryAPICheck(l) == nil
+}
+
 func WaitOnAPI(l testbedi.Libp2p) error {
 	for i := 0; i < 50; i++ {
 		err := tryAPICheck(l)

--- a/util.go
+++ b/util.go
@@ -259,10 +259,12 @@ func tryAPICheck(l testbedi.Libp2p) error {
 		return err
 	}
 
-	resp, err := http.Get(fmt.Sprintf("http://%s:%s/api/v0/id", ip, pt))
+	httpc := &http.Client{Timeout: 200 * time.Millisecond}
+	resp, err := httpc.Get(fmt.Sprintf("http://%s:%s/api/v0/id", ip, pt))
 	if err != nil {
 		return err
 	}
+	defer resp.Body.Close()
 
 	out := make(map[string]interface{})
 	err = json.NewDecoder(resp.Body).Decode(&out)


### PR DESCRIPTION
Related to https://github.com/ipfs/iptb/pull/118
`local` plugin seemed to already have it's own mechanism to figure out if node is running.
For all the other plugins I used the already defined `tryAPICheck` util func.